### PR TITLE
Fix dependencies in .egg file

### DIFF
--- a/binary-heap.egg
+++ b/binary-heap.egg
@@ -3,6 +3,6 @@
  (synopsis "Binary heap.")
  (license "GPL-3")
  (category data)
- (dependencies datatype matchable)
+ (dependencies srfi-1 datatype matchable)
  (test-dependencies test)
  (components (extension binary-heap)))


### PR DESCRIPTION
Sorry for bothering again, but it looks like `srfi-1` is required in the dependencies of the egg file, otherwise it won't pass the [test-new-egg](https://wiki.call-cc.org/eggref/5/test-new-egg) tool's check. Would you mind merging this PR and retagging it as 2.1? I have already edited the [documentation](https://wiki.call-cc.org/eggref/5/binary-heap) and  run test-new-egg locally. After modifying the dependencies, this egg should be ready to be added to CHICKEN 5's egg index.

    ==== binary-heap (1 of 1) ====
      Fetching........................................[ ok ] 0s
      Reading .egg....................................[ ok ] 0s
      Checking dependencies...........................[ ok ] 0s
      Checking category...............................[ ok ] 0s
      Checking license................................[ ok ] 0s
      Checking author.................................[ ok ] 0s
      Installing......................................[ ok ] 1m52s
      Checking version................................[ -- ] 
      Testing.........................................[ ok ] 28s
      Checking documentation..........................[ ok ] 3s
    Removing /tmp/tempede5.39807
    Egg looks ok!
